### PR TITLE
Fix Message typespec

### DIFF
--- a/lib/message.ex
+++ b/lib/message.ex
@@ -16,7 +16,7 @@ defmodule Clover.Message do
 
   @type t :: %__MODULE__{
           mentions: mentions(),
-          robot: pid(),
+          robot: String.t(),
           room: String.t(),
           text: String.t(),
           type: String.t(),


### PR DESCRIPTION
`robot` used to be a pid, but with registry, is now a string